### PR TITLE
Check that sbt in project dir is executable file

### DIFF
--- a/lib/sbt.js
+++ b/lib/sbt.js
@@ -23,7 +23,14 @@ export function provideBuilder() {
 
     settings() {
       const projectSbt = path.join(this.cwd, 'sbt');
-      const executable = fs.existsSync(projectSbt) ? projectSbt : 'sbt';
+      var projectSbtExecutable = false;
+      try {
+        const stats = fs.statSync(projectSbt);
+        projectSbtExecutable = stats.isFile() && fs.accessSync(projectSbt, fs.X_OK);
+      } catch(e){
+        console.log(e);
+      }
+      const executable = projectSbtExecutable ? projectSbt : 'sbt';
       const errorMatch = [
         '\\[error\\] (?<file>[^:\\n]+):(?<line>\\d+):'
       ];


### PR DESCRIPTION
Hi, James!
I discovered that build-sbt fails to register itself as build provider when there is a directory with name sbt exists in project root folder. So I propose following solution to solve this problem.
